### PR TITLE
Add reusable release workflows

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,17 @@
+name: Post Release
+
+on:
+  workflow_run:
+    workflows: ["Publish Release"]
+    types:
+      - completed
+
+jobs:
+  bump-dev-version:
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: AlchemyCMS/.github/.github/workflows/post-release.yml@main
+    with:
+      version_file_path: lib/alchemy/bugsnag/version.rb
+    secrets:
+      app_id: ${{ vars.ALCHEMY_BOT_APP_ID }}
+      app_private_key: ${{ secrets.ALCHEMY_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,3 +15,8 @@ jobs:
     secrets:
       app_id: ${{ vars.ALCHEMY_BOT_APP_ID }}
       app_private_key: ${{ secrets.ALCHEMY_BOT_APP_PRIVATE_KEY }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      mastodon_access_token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+      mastodon_instance: ${{ secrets.MASTODON_INSTANCE }}
+      bluesky_identifier: ${{ secrets.BLUESKY_IDENTIFIER }}
+      bluesky_password: ${{ secrets.BLUESKY_PASSWORD }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,25 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type. Choose "release" for finalizing a pre-release, or patch/minor/major to bump version.'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - release
+          - patch
+          - minor
+          - major
+
+jobs:
+  prepare:
+    uses: AlchemyCMS/.github/.github/workflows/prepare-release.yml@main
+    with:
+      version_file_path: lib/alchemy/bugsnag/version.rb
+      bump: ${{ inputs.bump }}
+    secrets:
+      app_id: ${{ vars.ALCHEMY_BOT_APP_ID }}
+      app_private_key: ${{ secrets.ALCHEMY_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  publish:
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v'))
+    uses: AlchemyCMS/.github/.github/workflows/release.yml@main
+    with:
+      version_file_path: lib/alchemy/bugsnag/version.rb
+    secrets:
+      app_id: ${{ vars.ALCHEMY_BOT_APP_ID }}
+      app_private_key: ${{ secrets.ALCHEMY_BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the shared release workflows from AlchemyCMS/.github:

- **prepare-release.yml** - Manually trigger to create a release PR
- **release.yml** - Publishes to RubyGems when release PR is merged
- **post-release.yml** - Bumps to next dev version after release